### PR TITLE
Allow HOCR validation to be disabled.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -80,6 +80,12 @@ function islandora_ocr_admin_settings_form(array $form, array &$form_state) {
         '#element_validate' => array('element_validate_number'),
         '#default_value' => $get_default_value('islandora_ocr_solr_hocr_result_count', '32'),
       ),
+      'islandora_ocr_validate_ocr_on_load' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Validate HOCR on load?'),
+        '#description' => t('Verify that HOCR loaded came from the required version of Tesseract.  May not be applicable if the HOCR came from another source.'),
+        '#default_value' => $get_default_value('islandora_ocr_validate_ocr_on_load', TRUE),
+      ),
     ));
 }
 

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -29,16 +29,20 @@ class HOCR {
    *
    * @param AbstractFedoraDatastream $datastream
    *   The datastream containing the HOCR file.
+   * @param array $options
+   *   An associative array of options to give to the HOCR constructor.
    *
    * @return HOCR
    *   An object of this class build from the given datastream.
+   *
+   * @see HOCR::__construct()
    */
-  public static function fromDatastream(AbstractFedoraDatastream $datastream) {
+  public static function fromDatastream(AbstractFedoraDatastream $datastream, array $options = array()) {
     $mime_detect = new MimeDetect();
     $ext = $mime_detect->getExtension($datastream->mimeType);
     $file = file_create_filename("{$datastream->parent->id}_{$datastream->id}.{$ext}", 'temporary://');
     $datastream->getContent($file);
-    $hocr = new HOCR($file);
+    $hocr = new HOCR($file, $options);
     file_unmanaged_delete($file);
     return $hocr;
   }
@@ -92,11 +96,20 @@ class HOCR {
    *
    * @param string $file
    *   The absolute path to the HOCR file.
+   * @param array $options
+   *   An associative array of options. Currently recognized:
+   *   - validate: A boolean indicating whether or not we should validate the
+   *     provided file, using HOCR::isValid(). Defaults to TRUE.
    *
    * @throws InvalidArgumentException
    */
-  public function __construct($file) {
-    if (!self::isValid($file)) {
+  public function __construct($file, array $options = array()) {
+    // Add in our default.
+    $options += array(
+      'validate' => TRUE,
+    );
+
+    if ($options['validate'] && !self::isValid($file)) {
       throw new InvalidArgumentException('Attempted to instantiate HOCR class without a valid HOCR file.');
     }
     $this->doc = new DOMDocument('1.0', 'UTF-8');

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -79,7 +79,9 @@ function islandora_ocr_map_highlighted_solr_results_to_bounding_boxes($solr_resu
   foreach ($highlighted_documents as $pid => $highlighted_fields) {
     $object = islandora_object_load($pid);
     if ($object && isset($object['HOCR'])) {
-      $hocr = HOCR::fromDatastream($object['HOCR']);
+      $hocr = HOCR::fromDatastream($object['HOCR'], array(
+        'validate' => variable_get('islandora_ocr_validate_ocr_on_load', TRUE),
+      ));
       $results[$pid] = array(
         'page' => $hocr->getPageDimensions(),
         'snippets' => array(),


### PR DESCRIPTION
HOCR might come from other places... Current validation assumes it
comes from Tesseract.  Default is still to try to perform validation.
