### PR TITLE
7.x grammar fixes

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -49,9 +49,9 @@ function islandora_ocr_admin_settings_form(array $form, array &$form_state) {
         '#options' => drupal_map_assoc($installed_languages, 'islandora_ocr_tesseract_language_name'),
         '#description' => t('Select from the language packs available on your
                              processing server.<br/> These are normally found in
-                             <strong>/usr/local/share/tessdata/</strong><br/>
+                             <strong>/usr/local/share/tessdata/</strong>.<br/>
                              Check with your systems admininistrator if you are
-                             unsure of availablilty'),
+                             unsure of availablilty.'),
         '#default_value' => $enabled_languages,
       ),
       'islandora_ocr_solr_hocr_highlighting_use_fast' => array(
@@ -69,13 +69,13 @@ function islandora_ocr_admin_settings_form(array $form, array &$form_state) {
         '#access' => $solr_enabled,
         '#type' => 'textfield',
         '#title' => t('Solr field containing OCR text'),
-        '#description' => t('The solr field to use for highlighting.<br/>If Fast Vector Highlighting is enabled some special requirements must be met.'),
+        '#description' => t('The Solr field to use for highlighting.<br/>If Fast Vector Highlighting is enabled, some special requirements must be met.'),
         '#default_value' => $get_default_value('islandora_ocr_solr_hocr_highlighting_field', 'text_nodes_HOCR_hlt'),
       ),
       'islandora_ocr_solr_hocr_result_count' => array(
         '#access' => $solr_enabled,
         '#type' => 'textfield',
-        '#title' => t('The maximum number of results to return in a solr query'),
+        '#title' => t('Maximum number of results to return in a Solr query'),
         '#description' => t('The maximum number of pages that will be returned by a full text search.'),
         '#element_validate' => array('element_validate_number'),
         '#default_value' => $get_default_value('islandora_ocr_solr_hocr_result_count', '32'),

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -52,7 +52,7 @@ function islandora_ocr_create_hocr($image_file, array $options) {
   $command = "{$executable} {$image_file} {$image_file} -l {$options['language']} hocr 2>&1";
   exec($command, $output, $ret);
   if ($ret != '0' || !file_exists($out_file)) {
-    $message = 'Tesseract failed to create HOCR datastreams.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
+    $message = 'Tesseract failed to create an HOCR datastream.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
@@ -62,7 +62,7 @@ function islandora_ocr_create_hocr($image_file, array $options) {
     return FALSE;
   }
   if (!HOCR::isValid($out_file)) {
-    $message = 'Tesseract failed to create valid HOCR datastreams. Please ensure you are running a supported version of Tesseract (3.02.02 or later).';
+    $message = 'Tesseract failed to create a valid HOCR datastream. Please ensure you are running a supported version of Tesseract (3.02.02 or later).';
     $message .= '<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
@@ -203,7 +203,7 @@ function islandora_ocr_imagemagick_convert($src, $dest, $args) {
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {
-    $message = 'ImageMagick failed to create any derivatives.<br/>Error: @ret<br/>Command: @command<br/>Output: @output';
+    $message = 'ImageMagick failed to create a derivative.<br/>Error: @ret<br/>Command: @command<br/>Output: @output';
     $variables = array('@ret' => $ret, '@command' => $command, '@output' => $output);
     watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
     return FALSE;

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -20,7 +20,7 @@ function islandora_ocr_create_ocr($image_file, array $options) {
   $command = "{$executable} {$image_file} {$image_file} -l {$options['language']} 2>&1";
   exec($command, $output, $ret);
   if ($ret != '0' || !file_exists($out_file)) {
-    $message = 'tesseract failed to create ocr<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
+    $message = 'Tesseract failed to create OCR datastreams.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
@@ -52,7 +52,7 @@ function islandora_ocr_create_hocr($image_file, array $options) {
   $command = "{$executable} {$image_file} {$image_file} -l {$options['language']} hocr 2>&1";
   exec($command, $output, $ret);
   if ($ret != '0' || !file_exists($out_file)) {
-    $message = 'tesseract failed to create hocr<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
+    $message = 'Tesseract failed to create HOCR datastreams.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
@@ -62,7 +62,7 @@ function islandora_ocr_create_hocr($image_file, array $options) {
     return FALSE;
   }
   if (!HOCR::isValid($out_file)) {
-    $message = 'tesseract failed to create valid hocr make sure to check your running a supported version of tesseract 3.2 or later.';
+    $message = 'Tesseract failed to create valid HOCR datastreams. Please ensure you are running a supported version of Tesseract (3.02.02 or later).';
     $message .= '<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
@@ -203,7 +203,7 @@ function islandora_ocr_imagemagick_convert($src, $dest, $args) {
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {
-    $message = 'ImageMagick convert failed to create derivative<br/>Error: @ret<br/>Command: @command<br/>Output: @output';
+    $message = 'ImageMagick failed to create any derivatives.<br/>Error: @ret<br/>Command: @command<br/>Output: @output';
     $variables = array('@ret' => $ret, '@command' => $command, '@output' => $output);
     watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
     return FALSE;

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -97,7 +97,7 @@ class HOCR {
    */
   public function __construct($file) {
     if (!self::isValid($file)) {
-      throw new InvalidArgumentException('Attempted to instantiate HOCR class without a valid HOCR file.');
+      throw new InvalidArgumentException('Attempted to instantiate the HOCR class without a valid HOCR file.');
     }
     $this->doc = new DOMDocument('1.0', 'UTF-8');
     $this->doc->load($file);

--- a/tests/hocr.test
+++ b/tests/hocr.test
@@ -37,7 +37,7 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
     try {
       $file = drupal_get_path('module', 'islandora_ocr') . '/tests/fixtures/test.tif';
       $hocr = new HOCR($file);
-      $this->fail('InvalidArgumentException was not thrown when invalid file parameter given.');
+      $this->fail('InvalidArgumentException not thrown when invalid file parameter given.');
     }
     catch(InvalidArgumentException $e) {
       $this->pass('InvalidArgumentException thrown when invalid file parameter given.');
@@ -50,40 +50,40 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
       $this->pass('No exception thrown when valid file parameter given.');
     }
     catch(Exception $e) {
-      $this->fail('Exception thrown when valid file parameter given.  '. $file);
+      $this->fail('Exception thrown when valid file parameter given. '. $file);
     }
     // Expecting count(//*[text()='the' or text()='The']) == 9
     $results = $hocr->search('ThE');
-    $this->assertEqual(count($results), 9, 'Default search was Case-insensitive search for "ThE", returned the expected number of results');
+    $this->assertEqual(count($results), 9, 'Default search was case-insensitive search for "ThE"; returned expected number of results');
     $classes = array_filter($results, function($o){return $o['class'] != 'ocrx_word';});
     $this->assertEqual(count($classes), 0, 'Default search only returned "ocrx_word" properties for "ThE".');
     // Expecting count(//*[text()='the']) == 5
     $results = $hocr->search('the', array('case_sensitive' => TRUE));
-    $this->assertEqual(count($results), 5, 'Case-sensitive search for "the", returned the expected number of results');
+    $this->assertEqual(count($results), 5, 'Case-sensitive search for "the" returned the expected number of results');
     // Get the unknown page dimensions returns false.
     $dimensions = $hocr->getPageDimensions(1);
     $this->assertFalse($dimensions, 'Get page dimensions returned FALSE for unknown page.');
     // Get the page dimensions.
     $dimensions = $hocr->getPageDimensions();
-    $this->assertEqual($dimensions, array('width' => 640, 'height' => 480), 'Get page dimensions returned the correct value.');
+    $this->assertEqual($dimensions, array('width' => 640, 'height' => 480), 'Get page dimensions returned correct value.');
     // Test Phrase matching.
     $results = $hocr->search('test the', array(
                  'case_sensitive' => TRUE,
                  'match_exact_phrase' => TRUE,
                ));
-    $this->assertEqual(count($results), 2, 'Match exact phrase "the test", returned the expected number of results');
+    $this->assertEqual(count($results), 2, 'Searching for match of exact phrase "the test" returned expected number of results');
     // Test Phrase matching case-insensitive.
     $results = $hocr->search('tESt tHe', array(
                  'case_sensitive' => FALSE,
                  'match_exact_phrase' => TRUE,
                ));
-    $this->assertEqual(count($results), 2, 'Case-Insensitive match exact phrase "the test", returned the expected number of results');
+    $this->assertEqual(count($results), 2, 'Searching for match of exact case-insensitive phrase "the test" returned expected number of results');
     // Test against Phrase matching.
     $results = $hocr->search('test the', array(
                  'case_sensitive' => TRUE,
                  'match_exact_phrase' => FALSE,
                ));
-    $this->assertEqual(count($results), 6, 'Test against exact phrase "the test", returned the expected number of results');
+    $this->assertEqual(count($results), 6, 'Test against exact phrase "the test" returned expected number of results');
     // Test Solr matching.
     $file = drupal_get_path('module', 'islandora_ocr') . '/tests/fixtures/solr_results.xml';
     $solr_results = simplexml_load_file($file);
@@ -97,6 +97,6 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
                  'case_sensitive' => TRUE,
                  'solr' => $solr_params,
                  'match_exact_phrase' => FALSE));
-    $this->assertEqual(count($results), 12, 'Solr search for "quick lazy fox", returned the expected number of results');
+    $this->assertEqual(count($results), 12, 'Solr search for "quick lazy fox" returned expected number of results');
   }
 }

--- a/tests/hocr.test
+++ b/tests/hocr.test
@@ -62,10 +62,10 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
     $this->assertEqual(count($results), 5, 'Case-sensitive search for "the" returned the expected number of results');
     // Get the unknown page dimensions returns false.
     $dimensions = $hocr->getPageDimensions(1);
-    $this->assertFalse($dimensions, 'Get page dimensions returned FALSE for unknown page.');
+    $this->assertFalse($dimensions, 'Get page dimensions returned FALSE for unknown page');
     // Get the page dimensions.
     $dimensions = $hocr->getPageDimensions();
-    $this->assertEqual($dimensions, array('width' => 640, 'height' => 480), 'Get page dimensions returned correct value.');
+    $this->assertEqual($dimensions, array('width' => 640, 'height' => 480), 'Get page dimensions returned correct value');
     // Test Phrase matching.
     $results = $hocr->search('test the', array(
                  'case_sensitive' => TRUE,


### PR DESCRIPTION
Mainly punctuation/capitalization, as well as tense, capitalization and punctuation consistency across test result messages.
