### PR TITLE
Optionally dedup Snippets, such that words will only be bound to one sni...

### DIFF
--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -62,35 +62,120 @@ function islandora_ocr_highlighted_solr_search($query, $offset = 0, $limit = -1,
  *
  * @param object $solr_results
  *   The Solr results; deserialized JSON.
- * @param array $solr_params
- *   SOLR query parameters.
+ * @param bool $ignore_duplicate_snippets_results
+ *   If TRUE ignore the exact words that are matched by multiple snippets.
  *
  * @return array
  *   An associative array containing all the relevent bounding information for
  *   highlighted search results:
  */
-function islandora_ocr_map_highlighted_solr_results_to_bounding_boxes($solr_results, $solr_params) {
+function islandora_ocr_map_highlighted_solr_results_to_bounding_boxes($solr_results, $ignore_duplicate_snippets_results = TRUE) {
   $results = array();
-  $params = $solr_results['responseHeader']['params'];
-  $highlighted_documents = $solr_results['highlighting'];
-  $map_hocr_search_result_to_bounding_box = function($o) {
-    return $o['bbox'];
-  };
-  foreach ($highlighted_documents as $pid => $highlighted_fields) {
+  $hocr_search_params = array(
+    'solr' => $solr_results['responseHeader']['params'],
+  );
+  foreach ($solr_results['highlighting'] as $pid => $highlighted_fields) {
     $object = islandora_object_load($pid);
-    if ($object && isset($object['HOCR'])) {
-      $hocr = HOCR::fromDatastream($object['HOCR']);
-      $results[$pid] = array(
-        'page' => $hocr->getPageDimensions(),
-        'snippets' => array(),
-      );
-      foreach ($highlighted_fields as $highlighted_field) {
-        foreach ($highlighted_field as $snippet) {
-          $matches = $hocr->search($snippet, array('solr' => $params));
-          $results[$pid]['snippets'][$snippet] = array_map($map_hocr_search_result_to_bounding_box, $matches);
-        }
+    if (!$object || empty($object['HOCR'])) {
+      continue;
+    }
+    $hocr = HOCR::fromDatastream($object['HOCR']);
+    $highlighted_words = islandora_ocr_map_highlighted_fields_to_words($hocr, $hocr_search_params, $highlighted_fields);
+    $snippets = islandora_ocr_map_highlighted_words_to_snippets($highlighted_words, $ignore_duplicate_snippets_results);
+    $results[$pid] = array(
+      'page' => $hocr->getPageDimensions(),
+      'snippets' => $snippets,
+    );
+  }
+  return $results;
+}
+
+/**
+ * Searches for every highlighted word and records what snippets they belong to.
+ *
+ * @param HOCR $hocr
+ *   Used to search the HOCR for the given highlighted fields.
+ * @param array $search_params
+ *   Parameters to pass onto the HOCR search.
+ * @param array $highlighted_fields
+ *   The highlighted fields of a solr result document.
+ *
+ * @return array
+ *   An associative array containing all the highlighted words.
+ *   - id: The ID of the word.
+ *     - id: The ID of the word.
+ *     - class: The class of the word.
+ *     - bbox: The bounding box of the word.
+ *     - snippets: The snippets this word belongs to.
+ */
+function islandora_ocr_map_highlighted_fields_to_words(HOCR $hocr, array $search_params, array $highlighted_fields) {
+  // Search for all the words in the snippet and combined them such that
+  // for all words we record all the snippets that they belong to.
+  $snippets = islandora_ocr_map_solr_highlighted_fields_to_snippets($highlighted_fields);
+  $highlighted_matches = array();
+  foreach ($snippets as $snippet) {
+    $matches = $hocr->search($snippet, $search_params);
+    foreach ($matches as $match) {
+      $id = $match['id'];
+      if (empty($highlighted_matches[$id])) {
+        $highlighted_matches[$id] = $match;
+      }
+      $highlighted_matches[$id]['snippets'][] = $snippet;
+    }
+  }
+  return $highlighted_matches;
+}
+
+/**
+ * Maps the given solr document results highlighted fields to snippets.
+ *
+ * @param array $highlighted_fields
+ *   The highlighted fields.
+ *
+ * @return array
+ *   The snippets.
+ */
+function islandora_ocr_map_solr_highlighted_fields_to_snippets(array $highlighted_fields) {
+  $snippets = array();
+  foreach ($highlighted_fields as $highlighted_field) {
+    foreach ($highlighted_field as $snippet) {
+      $snippets[] = $snippet;
+    }
+  }
+  return $snippets;
+}
+
+/**
+ * Maps the given highlighted words bounding boxes to snippets they belong to.
+ *
+ * @see islandora_ocr_map_highlighted_fields_to_words()
+ *
+ * @param array $highlighted_words
+ *   The highlighted words.
+ *
+ * @param bool $ignore_duplicate_snippets_results
+ *   If TRUE only the first matching snippet is populated in the results for a
+ *   given word.
+ *
+ * @return array
+ *   An associative array where the keys are the solr snippets, and the values
+ *   are array's of bounding boxes for each of the highlighted words in the
+ *   solr snippet.
+ */
+function islandora_ocr_map_highlighted_words_to_snippets(array $highlighted_words, $ignore_duplicate_snippets_results) {
+  $snippets = array();
+  if ($ignore_duplicate_snippets_results) {
+    foreach ($highlighted_words as $word) {
+      $snippet = $word['snippets'][0];
+      $snippets[$snippet][] = $word['bbox'];
+    }
+  }
+  else {
+    foreach ($highlighted_words as $word) {
+      foreach ($word['snippets'] as $snippet) {
+        $snippets[$snippet][] = $word['bbox'];
       }
     }
   }
-  return $results;
+  return $snippets;
 }


### PR DESCRIPTION
...ppet.

OnTime: #1332 HOCR Bounding Box "Deduplication"

This is achieved by adding an additional default parameter to the solr results
function, that defaults to bounding a word to only a single snippet.

Also includes: https://github.com/Islandora/islandora_paged_content/pull/16
