### PR TITLE
Strip DOCTYPE from HOCR (and code standards).

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -65,6 +65,7 @@ function islandora_ocr_create_hocr($image_file, array $options) {
     watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
     return FALSE;
   }
+
   if (!HOCR::isValid($out_file)) {
     $message = 'tesseract failed to create valid hocr make sure to check your running a supported version of tesseract 3.2 or later.';
     $message .= '<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
@@ -76,6 +77,9 @@ function islandora_ocr_create_hocr($image_file, array $options) {
     watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
     return FALSE;
   }
+
+  HOCR::stripDoctypeFromFile($out_file);
+
   return $out_file;
 }
 

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -579,9 +579,9 @@ class HOCR {
   public static function stripDoctypeFromFile($filename) {
     $file = fopen($filename, 'r+');
     if ($file) {
-      $stripped_content = self::stripDoctype(fread($file, filesize($filename)))
+      $stripped_content = self::stripDoctype(fread($file, filesize($filename)));
       fseek($file, 0);
-      ftruncate($file);
+      ftruncate($file, 0);
       fwrite($file, $stripped_content);
       fclose($file);
     }

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -546,4 +546,44 @@ class HOCR {
     }
     return array('width' => $width, 'height' => $height);
   }
+
+  /**
+   * Strip the DOCTYPE declaration from the related HOCR.
+   *
+   * Fedora GSearch (or Java in general) does not handle (XML) entity
+   * resolution gracefully by default (tries to hit w3.org to retrieve DTDs)...
+   * Ideally, a functional entity resolver could be made to be used on the Java
+   * side; however, this seems like it would necessitate setting up the parser
+   * in a different way, which seems like a non-trivial change in GSearch.
+   * Alternatively, it seems like there should be a flag to change the HOCR
+   * tesseract outputs; however, reviewing the
+   * @link http://code.google.com/p/tesseract-ocr/source/browse/trunk/api/baseapi.cpp#830 source code @endlink
+   * reveals that it is highly unlikely that such a flag exists. Seems simpler
+   * just to wipe it.
+   */
+  public static function stripDoctype($hocr_string) {
+    // Seems arbitrary, but this is what is hard-coded in tesseract (see the
+    // link in this method's doc-comment.
+    $doctype = '
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
+
+    return str_replace($doctype, '', $hocr_string);
+  }
+
+  /**
+   * Strip the DOCTYPE declaration from a file containing HOCR.
+   *
+   * @see HOCR::stripDoctype()
+   */
+  public static function stripDoctypeFromFile($filename) {
+    $file = fopen($filename, 'r+');
+    if ($file) {
+      $stripped_content = self::stripDoctype(fread($file, filesize($filename)))
+      fseek($file, 0);
+      ftruncate($file);
+      fwrite($file, $stripped_content);
+      fclose($file);
+    }
+  }
 }

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -562,13 +562,10 @@ class HOCR {
    * just to wipe it.
    */
   public static function stripDoctype($hocr_string) {
-    // Seems arbitrary, but this is what is hard-coded in tesseract (see the
-    // link in this method's doc-comment.
-    $doctype = '
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
+    // Wipe out the HTML DOCTYPE definition.
+    $doctype_regex = '/<!DOCTYPE\s+html.*?>\s+/si';
 
-    return str_replace($doctype, '', $hocr_string);
+    return preg_replace($doctype_regex, '', $hocr_string);
   }
 
   /**

--- a/tests/hocr.test
+++ b/tests/hocr.test
@@ -39,7 +39,7 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
       $hocr = new HOCR($file);
       $this->fail('InvalidArgumentException was not thrown when invalid file parameter given.');
     }
-    catch(InvalidArgumentException $e) {
+    catch (InvalidArgumentException $e) {
       $this->pass('InvalidArgumentException thrown when invalid file parameter given.');
     }
     // Test correct arguments do not throw.
@@ -49,13 +49,13 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
       $hocr = new HOCR($file);
       $this->pass('No exception thrown when valid file parameter given.');
     }
-    catch(Exception $e) {
+    catch (Exception $e) {
       $this->fail('Exception thrown when valid file parameter given.  ' . $file);
     }
     // Expecting count(//*[text()='the' or text()='The']) == 9
     $results = $hocr->search('ThE');
     $this->assertEqual(count($results), 9, 'Default search was Case-insensitive search for "ThE", returned the expected number of results');
-    $classes = array_filter($results, function($o){return $o['class'] != 'ocrx_word';});
+    $classes = array_filter($results, function ($o) {return $o['class'] != 'ocrx_word';});
     $this->assertEqual(count($classes), 0, 'Default search only returned "ocrx_word" properties for "ThE".');
     // Expecting count(//*[text()='the']) == 5
     $results = $hocr->search('the', array('case_sensitive' => TRUE));


### PR DESCRIPTION
Slows down indexing due to timeouts trying to access DTDs at w3.org, as GSearch does not specify a sane entity resolver.
