### PR TITLE
Use drupal_realpath(), to help ensure that the ftruncate() will work.

### DIFF
--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -574,6 +574,7 @@ class HOCR {
    * @see HOCR::stripDoctype()
    */
   public static function stripDoctypeFromFile($filename) {
+    $filename = drupal_realpath($filename);
     $file = fopen($filename, 'r+');
     if ($file) {
       $stripped_content = self::stripDoctype(fread($file, filesize($filename)));


### PR DESCRIPTION
Looks like the "temporary://" stream wrapper that Drupal includes does
not support ftruncate()...  Resolving the URI to a file works, though.
