### PR TITLE
Windows-compatibility: Tesseract version number

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,7 +34,7 @@ function islandora_ocr_admin_settings_form(array $form, array &$form_state) {
         '#type' => 'textfield',
         '#title' => t('Tesseract'),
         '#description' => t('Tesseract is used to generate the OCR and coordinate data.<br/>!msg', array(
-                          '!msg' => islandora_executable_available_message($tesseract, $version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION))),
+                          '!msg' => islandora_executable_available_message($tesseract, $version, islandora_ocr_required_tesseract_version()))),
         '#default_value' => $tesseract,
         '#ajax' => array(
           'callback' => 'islandora_ocr_admin_settings_form_ajax_callback',

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -56,9 +56,10 @@ class HOCR {
    *   TRUE if the HOCR file is valid, FALSE otherwise.
    */
   public static function isValid($file) {
+    module_load_include('inc', 'islandora_ocr', 'includes/utilities');
     if (file_exists($file)) {
       $version = self::getVersion($file);
-      return version_compare($version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION) >= 0;
+      return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
     }
     return FALSE;
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -13,7 +13,7 @@
  */
 function islandora_ocr_can_derive_ocr() {
   $version = islandora_ocr_get_tesseract_version();
-  return version_compare($version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION) >= 0;
+  return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
 }
 
 /**
@@ -38,6 +38,27 @@ function islandora_ocr_get_tesseract_version($tesseract = NULL) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Returns the Tesseract version number required, based on server OS.
+ *
+ * @return string
+ *   The required Tesseract version number.
+ */
+function islandora_ocr_required_tesseract_version() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $tesseract_required_version_number = '3.02.02';
+
+  if (islandora_deployed_on_windows()) {
+    // For some reason, Tesseract 3.02.02 for Windows identifies itself
+    // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
+    // the version number allows Windows installations to use OCR again.
+    $tesseract_required_version_number = '3.02';
+  }
+
+  return $tesseract_required_version_number;
 }
 
 /**

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,8 +5,19 @@
  * Defines all the hooks this module implements.
  */
 
+$tesseract_required_version_number = '3.02.02';
+
+// Determine if the server is running Windows.
+if (islandora_os_check() == "Windows") {
+  // For some reason, the Windows version of Tesseract identifies itself
+  // incorrectly. Despite downloading and installing the "3.02.02" version,
+  // running "tesseract -v" gives the incorrect response "tesseract 3.02".
+  // This hack makes it possible to still use OCR under Windows.
+  $tesseract_required_version_number = '3.02';
+}
+
 // Constants.
-define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02');
+define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', $tesseract_required_version_number);
 
 /**
  * Implements hook_menu().

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,7 +5,7 @@
  * Defines all the hooks this module implements.
  */
 
-// Constant (deprecated)
+// Constant (deprecated).
 define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02');
 
 /**

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,8 +5,8 @@
  * Defines all the hooks this module implements.
  */
 
-// Constant.
-define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', islandora_ocr_tesseract_version_number());
+// Constants.
+define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02'); // deprecated
 
 /**
  * Implements hook_menu().
@@ -23,25 +23,4 @@ function islandora_ocr_menu() {
       'type' => MENU_NORMAL_ITEM,
     ),
   );
-}
-
-/**
- * Returns the appropriate Tesseract version number, based on server OS.
- *
- * @return string
- *   The Tesseract version number.
- */
-function islandora_ocr_tesseract_version_number() {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-
-  $tesseract_required_version_number = '3.02.02';
-
-  if (islandora_deployed_on_windows()) {
-    // For some reason, Tesseract 3.02.02 for Windows identifies itself
-    // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
-    // the version number allows Windows installations to use OCR again.
-    $tesseract_required_version_number = '3.02';
-  }
-
-  return $tesseract_required_version_number;
 }

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -9,10 +9,9 @@ module_load_include('inc', 'islandora', 'includes/utilities');
 
 $tesseract_required_version_number = '3.02.02';
 
-// Determine if the server's operating system is Windows.
 if (islandora_deployed_on_windows()) {
-  // slangerx: For some reason, Tesseract 3.02.02 for Windows
-  // identifies itself incorrectly: "tesseract -v" = "tesseract 3.02"
+  // For some reason, Tesseract 3.02.02 for Windows identifies
+  // itself incorrectly: "tesseract -v" returns "tesseract 3.02"
   // This hack makes it possible to still use OCR under Windows.
   $tesseract_required_version_number = '3.02';
 }

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,10 +5,12 @@
  * Defines all the hooks this module implements.
  */
 
+module_load_include('inc', 'islandora', 'includes/utilities');
+
 $tesseract_required_version_number = '3.02.02';
 
-// Determine if the server is running Windows.
-if (islandora_os_check() == "Windows") {
+// Determine if the server's operating system is Windows.
+if (islandora_deployed_on_windows()) {
   // slangerx: For some reason, Tesseract 3.02.02 for Windows
   // identifies itself incorrectly: "tesseract -v" = "tesseract 3.02"
   // This hack makes it possible to still use OCR under Windows.

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,8 +5,8 @@
  * Defines all the hooks this module implements.
  */
 
-// Constants.
-define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02'); // deprecated
+// Constant (deprecated)
+define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02');
 
 /**
  * Implements hook_menu().

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -10,8 +10,10 @@ $tesseract_required_version_number = '3.02.02';
 // Determine if the server is running Windows.
 if (islandora_os_check() == "Windows") {
   // For some reason, the Windows version of Tesseract identifies itself
-  // incorrectly. Despite downloading and installing the "3.02.02" version,
-  // running "tesseract -v" gives the incorrect response "tesseract 3.02".
+  // incorrectly. Despite downloading and installing the "3.02.02" version
+  // ("tesseract-ocr-setup-3.02.02.exe", located here:
+  // https://code.google.com/p/tesseract-ocr/downloads/list),
+  // running "tesseract -v" gives the incorrect response: "tesseract 3.02".
   // This hack makes it possible to still use OCR under Windows.
   $tesseract_required_version_number = '3.02';
 }

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,7 +5,7 @@
  * Defines all the hooks this module implements.
  */
 
-// Constants.
+// Constant.
 define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', islandora_ocr_tesseract_version_number());
 
 /**
@@ -29,7 +29,7 @@ function islandora_ocr_menu() {
  * Get the required Tesseract version number, based on server OS.
  *
  * @return string
- *   The Tesseract version number required by this module.
+ *   The Tesseract version number.
  */
 function islandora_ocr_tesseract_version_number() {
   module_load_include('inc', 'islandora', 'includes/utilities');

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -26,7 +26,7 @@ function islandora_ocr_menu() {
 }
 
 /**
- * Get the required Tesseract version number, based on server OS.
+ * Returns the appropriate Tesseract version number, based on server OS.
  *
  * @return string
  *   The Tesseract version number.

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,19 +5,8 @@
  * Defines all the hooks this module implements.
  */
 
-module_load_include('inc', 'islandora', 'includes/utilities');
-
-$tesseract_required_version_number = '3.02.02';
-
-if (islandora_deployed_on_windows()) {
-  // For some reason, Tesseract 3.02.02 for Windows identifies itself
-  // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
-  // the version number allows Windows installations to use OCR again.
-  $tesseract_required_version_number = '3.02';
-}
-
 // Constants.
-define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', $tesseract_required_version_number);
+define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', islandora_ocr_tesseract_version_number());
 
 /**
  * Implements hook_menu().
@@ -34,4 +23,25 @@ function islandora_ocr_menu() {
       'type' => MENU_NORMAL_ITEM,
     ),
   );
+}
+
+/**
+ * Get the required Tesseract version number, based on server OS.
+ *
+ * @return string
+ *   The Tesseract version number required by this module.
+ */
+function islandora_ocr_tesseract_version_number() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $tesseract_required_version_number = '3.02.02';
+
+  if (islandora_deployed_on_windows()) {
+    // For some reason, Tesseract 3.02.02 for Windows identifies itself
+    // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
+    // the version number allows Windows installations to use OCR again.
+    $tesseract_required_version_number = '3.02';
+  }
+
+  return $tesseract_required_version_number;
 }

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -10,9 +10,9 @@ module_load_include('inc', 'islandora', 'includes/utilities');
 $tesseract_required_version_number = '3.02.02';
 
 if (islandora_deployed_on_windows()) {
-  // For some reason, Tesseract 3.02.02 for Windows identifies
-  // itself incorrectly: "tesseract -v" returns "tesseract 3.02"
-  // This hack makes it possible to still use OCR under Windows.
+  // For some reason, Tesseract 3.02.02 for Windows identifies itself
+  // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
+  // the version number allows Windows installations to use OCR again.
   $tesseract_required_version_number = '3.02';
 }
 

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -9,11 +9,11 @@ $tesseract_required_version_number = '3.02.02';
 
 // Determine if the server is running Windows.
 if (islandora_os_check() == "Windows") {
-  // For some reason, the Windows version of Tesseract identifies itself
-  // incorrectly. Despite downloading and installing the "3.02.02" version
-  // ("tesseract-ocr-setup-3.02.02.exe", located here:
+  // slangerx: For some reason, the Windows version of Tesseract identifies
+  // itself incorrectly. Despite downloading and installing the "3.02.02"
+  // version ("tesseract-ocr-setup-3.02.02.exe", located here:
   // https://code.google.com/p/tesseract-ocr/downloads/list),
-  // running "tesseract -v" gives the incorrect response: "tesseract 3.02".
+  // running "tesseract -v" gives the incorrect response: "tesseract 3.02"
   // This hack makes it possible to still use OCR under Windows.
   $tesseract_required_version_number = '3.02';
 }

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -9,11 +9,8 @@ $tesseract_required_version_number = '3.02.02';
 
 // Determine if the server is running Windows.
 if (islandora_os_check() == "Windows") {
-  // slangerx: For some reason, the Windows version of Tesseract identifies
-  // itself incorrectly. Despite downloading and installing the "3.02.02"
-  // version ("tesseract-ocr-setup-3.02.02.exe", located here:
-  // https://code.google.com/p/tesseract-ocr/downloads/list),
-  // running "tesseract -v" gives the incorrect response: "tesseract 3.02"
+  // slangerx: For some reason, Tesseract 3.02.02 for Windows
+  // identifies itself incorrectly: "tesseract -v" = "tesseract 3.02"
   // This hack makes it possible to still use OCR under Windows.
   $tesseract_required_version_number = '3.02';
 }


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

For some reason, the Windows version of Tesseract identifies itself incorrectly. This hack makes it possible to use the Islandora OCR module on a Windows installation despite this.

To elaborate:

> The [Islandora documentation](https://wiki.duraspace.org/display/ISLANDORA712/Tesseract) directs Windows users to the [tesseract-ocr](https://code.google.com/p/tesseract-ocr/downloads/list) page, which is maintained by Google. There is a tesseract-ocr 3.02.02 Windows installer there ("tesseract-ocr-setup-3.02.02.exe"), which I used to set up Tesseract.
> 
> Although the installation was successful, running "tesseract -v" or "tesseract --version" returns the following version information: "tesseract 3.02", which is obviously incomplete. This is why this patch was created. Otherwise, the Islandora OCR module won't work for Windows installations.

_NOTE 1:_ If there was another Windows installer for Tesseract out there that identified itself correctly, then this patch would no longer be necessary. 

_NOTE 2:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
