### PR TITLE
Windows-compatibility: Tesseract version number (7.x-1.3)

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,7 +34,7 @@ function islandora_ocr_admin_settings_form(array $form, array &$form_state) {
         '#type' => 'textfield',
         '#title' => t('Tesseract'),
         '#description' => t('Tesseract is used to generate the OCR and coordinate data.<br/>!msg', array(
-                          '!msg' => islandora_executable_available_message($tesseract, $version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION))),
+                          '!msg' => islandora_executable_available_message($tesseract, $version, islandora_ocr_required_tesseract_version()))),
         '#default_value' => $tesseract,
         '#ajax' => array(
           'callback' => 'islandora_ocr_admin_settings_form_ajax_callback',

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -56,9 +56,10 @@ class HOCR {
    *   TRUE if the HOCR file is valid, FALSE otherwise.
    */
   public static function isValid($file) {
+    module_load_include('inc', 'islandora_ocr', 'includes/utilities');
     if (file_exists($file)) {
       $version = self::getVersion($file);
-      return version_compare($version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION) >= 0;
+      return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
     }
     return FALSE;
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -13,7 +13,7 @@
  */
 function islandora_ocr_can_derive_ocr() {
   $version = islandora_ocr_get_tesseract_version();
-  return version_compare($version, ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION) >= 0;
+  return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
 }
 
 /**
@@ -38,6 +38,27 @@ function islandora_ocr_get_tesseract_version($tesseract = NULL) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Returns the Tesseract version number required, based on server OS.
+ *
+ * @return string
+ *   The required Tesseract version number.
+ */
+function islandora_ocr_required_tesseract_version() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $tesseract_required_version_number = '3.02.02';
+
+  if (islandora_deployed_on_windows()) {
+    // For some reason, Tesseract 3.02.02 for Windows identifies itself
+    // incorrectly: "tesseract -v" returns "tesseract 3.02". Adjusting
+    // the version number allows Windows installations to use OCR again.
+    $tesseract_required_version_number = '3.02';
+  }
+
+  return $tesseract_required_version_number;
 }
 
 /**

--- a/islandora_ocr.module
+++ b/islandora_ocr.module
@@ -5,7 +5,7 @@
  * Defines all the hooks this module implements.
  */
 
-// Constants.
+// Constant (deprecated).
 define('ISLANDORA_OCR_TESSERACT_REQUIRED_VERSION', '3.02.02');
 
 /**


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

For some reason, the Windows version of Tesseract identifies itself incorrectly. This code makes it possible to use the Islandora OCR module on a Windows installation despite this.

To elaborate:

> The [Islandora documentation](https://wiki.duraspace.org/display/ISLANDORA712/Tesseract) directs Windows users to the [tesseract-ocr](https://code.google.com/p/tesseract-ocr/downloads/list) page, which is maintained by Google. There is a tesseract-ocr 3.02.02 Windows installer there ("tesseract-ocr-setup-3.02.02.exe"), which I used to set up Tesseract.
> 
> Although the installation was successful, running "tesseract -v" or "tesseract --version" returns the following version information: "tesseract 3.02", which is obviously incomplete. This is why this patch was created. Otherwise, the Islandora OCR module won't work for Windows installations.

_NOTE 1:_ If there was another Windows installer for Tesseract out there that identified itself correctly, then this patch would no longer be necessary. 

_NOTE 2:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
