### PR TITLE
Delayed OCR generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_install:
 script:
   - ant -buildfile sites/all/modules/islandora_ocr/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_ocr
-  - drush dcs sites/all/modules/islandora_ocr
+  - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_ocr
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_ocr
   - drush test-run --uri=http://localhost:8081 "Islandora OCR"

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -116,11 +116,17 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
  *   The page datastream that the derivatives will be generated for.
  * @param array $options
  *   The options for tesseract.
+ * @param bool $ingest
+ *   Whether or not to ingest the datastreams now; otherwise, references will
+ *   be returned to the converted files.
  *
- * @return bool
- *   TRUE on success, FALSE otherwise.
+ * @return bool|array
+ *   If $ingest is true, this returns TRUE on success and FALSE on failure. If
+ *   $ingest is FALSE, this returns an associative array containing 'OCR' and
+ *   'HOCR', each paired with either the path to their respective file, or FALSE
+ *   if generation of that datastream had failed.
  */
-function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options) {
+function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options, $ingest = TRUE) {
   module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   $options += array(
     'language' => 'eng',
@@ -160,13 +166,24 @@ function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array 
 
   $ocr_file = islandora_ocr_create_ocr($source_file, $options);
   $hocr_file = islandora_ocr_create_hocr($source_file, $options);
-  $ret = $ocr_file;
-  $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $ocr_file, 'OCR');
-  $ret = $ret && $hocr_file;
-  $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $hocr_file, 'HOCR');
+  if ($ingest) {
+    $ret = $ocr_file;
+    $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $ocr_file, 'OCR');
+    $ret = $ret && $hocr_file;
+    $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $hocr_file, 'HOCR');
 
-  $files = array_filter(array($source_file, $ocr_file, $hocr_file));
-  array_map('file_unmanaged_delete', $files);
+    $files = array_filter(array($source_file, $ocr_file, $hocr_file));
+    array_map('file_unmanaged_delete', $files);
+  }
+  else {
+    $ret = $ocr_file && $hocr_file;
+    if ($ret !== FALSE) {
+      $ret = array(
+        'OCR' => $ocr_file,
+        'HOCR' => $hocr_file,
+      );
+    }
+  }
   return $ret;
 }
 

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -26,13 +26,12 @@ function islandora_ocr_create_ocr($image_file, array $options) {
   $command = "{$executable} {$image_file} {$image_file} -l {$options['language']} 2>&1";
   exec($command, $output, $ret);
   if ($ret != '0' || !file_exists($out_file)) {
-    $message = 'Tesseract failed to create OCR datastreams.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
       '!output' => implode('<br/>', $output),
     );
-    watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
+    watchdog('islandora_ocr', 'Tesseract failed to create OCR datastreams.<br/>Error: @ret<br/>Command: @command<br/>Output: !output', $variables, WATCHDOG_ERROR);
     return FALSE;
   }
   return $out_file;
@@ -65,25 +64,26 @@ function islandora_ocr_create_hocr($image_file, array $options) {
     $out_file = file_unmanaged_move("$image_file.hocr", "temporary://$base_name.html", FILE_EXISTS_REPLACE);
   }
   if ($ret != '0' || empty($out_file) || !file_exists($out_file)) {
-    $message = 'Tesseract failed to create an HOCR datastream.<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
       '!output' => implode('<br/>', $output),
     );
-    watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
+    watchdog('islandora_ocr', 'Tesseract failed to create an HOCR datastream.<br/>Error: @ret<br/>Command: @command<br/>Output: !output', $variables, WATCHDOG_ERROR);
     return FALSE;
   }
 
   if (!HOCR::isValid($out_file)) {
-    $message = 'Tesseract failed to create a valid HOCR datastream. Please ensure you are running a supported version of Tesseract (3.02.02 or later).';
-    $message .= '<br/>Error: @ret<br/>Command: @command<br/>Output: !output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
       '!output' => implode('<br/>', $output),
     );
-    watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
+    watchdog('islandora_ocr',
+      'Tesseract failed to create a valid HOCR datastream. Please ensure you are running a supported version of Tesseract (3.02.02 or later).<br/>Error: @ret<br/>Command: @command<br/>Output: !output',
+      $variables,
+      WATCHDOG_ERROR
+    );
     return FALSE;
   }
 
@@ -414,13 +414,12 @@ function islandora_ocr_imagemagick_convert($src, $dest, $args) {
   $output = '';
   $ret = -1;
   if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {
-    $message = 'ImageMagick failed to create a derivative.<br/>Error: @ret<br/>Command: @command<br/>Output: @output';
     $variables = array(
       '@ret' => $ret,
       '@command' => $command,
       '@output' => $output,
     );
-    watchdog('islandora_ocr', $message, $variables, WATCHDOG_ERROR);
+    watchdog('islandora_ocr', 'ImageMagick failed to create a derivative.<br/>Error: @ret<br/>Command: @command<br/>Output: @output', $variables, WATCHDOG_ERROR);
     return FALSE;
   }
   return $dest;

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -117,7 +117,7 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
  * @param array $options
  *   The options for tesseract.
  *
- * @return bool|array
+ * @return bool
  *   Returns TRUE on success and FALSE on failure.
  */
 function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -110,7 +110,7 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
 }
 
 /**
- * Creates and adds the OCR, HOCR datastreams.
+ * Generates OCR and HOCR derivatives from a page and adds them as datastreams.
  *
  * @param AbstractDatastream $datastream
  *   The page datastream that the derivatives will be generated for.
@@ -121,7 +121,7 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
  *   Returns TRUE on success and FALSE on failure.
  */
 function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options) {
-  $derivatives = islandora_ocr_generate_datastreams($datastream, $options);
+  $derivatives = islandora_ocr_generate_derivatives($datastream, $options);
   $ret = $derivatives['OCR'];
   $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $derivatives['OCR'], 'OCR');
   $ret = $ret && $derivatives['HOCR'];
@@ -133,7 +133,7 @@ function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array 
 }
 
 /**
- * Generates OCR/HOCR datastreams and returns references to them.
+ * Generates OCR/HOCR derivatives and returns references to them.
  *
  * @param AbstractDatastream $datastream
  *   The page datastream to generate derivatives for.
@@ -142,9 +142,9 @@ function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array 
  *
  * @return array
  *   An associative array containing 'OCR' and 'HOCR', paired with either the
- *   path to each datastream, or FALSE on failure.
+ *   path to that derivative, or FALSE on failure.
  */
-function islandora_ocr_generate_datastreams(AbstractDatastream $datastream, array $options) {
+function islandora_ocr_generate_derivatives(AbstractDatastream $datastream, array $options) {
   module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   $options += array(
     'language' => 'eng',

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -117,8 +117,10 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
  * @param array $options
  *   The options for tesseract.
  * @param bool $ingest
- *   Whether or not to ingest the datastreams now; otherwise, references will
- *   be returned to the converted files.
+ *   Whether or not to ingest the datastreams during the execution of this
+ *   function and then clean up the generated OCR files from the temp folder;
+ *   otherwise, references will be returned to the converted files, and
+ *   generated files will have to be cleaned up later.
  *
  * @return bool|array
  *   If $ingest is true, this returns TRUE on success and FALSE on failure. If

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -116,19 +116,35 @@ function islandora_ocr_get_uploaded_file(AbstractDatastream $datastream) {
  *   The page datastream that the derivatives will be generated for.
  * @param array $options
  *   The options for tesseract.
- * @param bool $ingest
- *   Whether or not to ingest the datastreams during the execution of this
- *   function and then clean up the generated OCR files from the temp folder;
- *   otherwise, references will be returned to the converted files, and
- *   generated files will have to be cleaned up later.
  *
  * @return bool|array
- *   If $ingest is true, this returns TRUE on success and FALSE on failure. If
- *   $ingest is FALSE, this returns an associative array containing 'OCR' and
- *   'HOCR', each paired with either the path to their respective file, or FALSE
- *   if generation of that datastream had failed.
+ *   Returns TRUE on success and FALSE on failure.
  */
-function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options, $ingest = TRUE) {
+function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array $options) {
+  $derivatives = islandora_ocr_generate_datastreams($datastream, $options);
+  $ret = $derivatives['OCR'];
+  $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $derivatives['OCR'], 'OCR');
+  $ret = $ret && $derivatives['HOCR'];
+  $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $derivatives['HOCR'], 'HOCR');
+
+  $files = array_filter(array($source_file, $ocr_file, $hocr_file));
+  array_map('file_unmanaged_delete', $files);
+  return $ret;
+}
+
+/**
+ * Generates OCR/HOCR datastreams and returns references to them.
+ *
+ * @param AbstractDatastream $datastream
+ *   The page datastream to generate derivatives for.
+ * @param array $options
+ *   Options for tesseract.
+ *
+ * @return array
+ *   An associative array containing 'OCR' and 'HOCR', paired with either the
+ *   path to each datastream, or FALSE on failure.
+ */
+function islandora_ocr_generate_datastreams(AbstractDatastream $datastream, array $options) {
   module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   $options += array(
     'language' => 'eng',
@@ -166,27 +182,10 @@ function islandora_ocr_derive_datastreams(AbstractDatastream $datastream, array 
     drupal_unlink($old_source);
   }
 
-  $ocr_file = islandora_ocr_create_ocr($source_file, $options);
-  $hocr_file = islandora_ocr_create_hocr($source_file, $options);
-  if ($ingest) {
-    $ret = $ocr_file;
-    $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $ocr_file, 'OCR');
-    $ret = $ret && $hocr_file;
-    $ret = $ret && islandora_ocr_update_datastream($datastream->parent, $hocr_file, 'HOCR');
-
-    $files = array_filter(array($source_file, $ocr_file, $hocr_file));
-    array_map('file_unmanaged_delete', $files);
-  }
-  else {
-    $ret = $ocr_file && $hocr_file;
-    if ($ret !== FALSE) {
-      $ret = array(
-        'OCR' => $ocr_file,
-        'HOCR' => $hocr_file,
-      );
-    }
-  }
-  return $ret;
+  return array(
+    'OCR' => islandora_ocr_create_ocr($source_file, $options),
+    'HOCR' => islandora_ocr_create_hocr($source_file, $options),
+  );
 }
 
 /**

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -11,6 +11,9 @@
  * document at a time.
  */
 
+/**
+ * HOCR class.
+ */
 class HOCR {
 
   /**
@@ -352,7 +355,7 @@ class HOCR {
    * Generates a phrase matching predicates that will only match nodes.
    *
    * Takes the form of:
-   * [text() = 'term_1' and following::*[1..n][text() = 
+   * [text() = 'term_1' and following::*[1..n][text() =
    * 'term_2..n']]/preceding::node()[1]/following::[position() <= n]
    *
    * @param array $terms

--- a/tests/hocr.test
+++ b/tests/hocr.test
@@ -5,12 +5,15 @@
  * Unit test for the HOCR class.
  */
 
+/**
+ * HOCR unit tests.
+ */
 class HOCRUnitTestCase extends DrupalWebTestCase {
 
   /**
    * Gets info to display to describe this test.
    *
-   * @see DrupalUnitTestCase::getInfo()
+   * @see DrupalWebTestCase::getInfo()
    */
   public static function getInfo() {
     return array(
@@ -23,7 +26,7 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
   /**
    * Sets up the requirements for this test.
    *
-   * @see DrupalUnitTestCase::setUp()
+   * @see DrupalWebTestCase::setUp()
    */
   public function setUp() {
     parent::setUp('islandora_ocr');
@@ -71,21 +74,21 @@ class HOCRUnitTestCase extends DrupalWebTestCase {
     $this->assertEqual($dimensions, array('width' => 640, 'height' => 480), 'Get page dimensions returned correct value');
     // Test Phrase matching.
     $results = $hocr->search('test the', array(
-                 'case_sensitive' => TRUE,
-                 'match_exact_phrase' => TRUE,
-               ));
+      'case_sensitive' => TRUE,
+      'match_exact_phrase' => TRUE,
+    ));
     $this->assertEqual(count($results), 2, 'Searching for match of exact phrase "the test" returned expected number of results');
     // Test Phrase matching case-insensitive.
     $results = $hocr->search('tESt tHe', array(
-                 'case_sensitive' => FALSE,
-                 'match_exact_phrase' => TRUE,
-               ));
+      'case_sensitive' => FALSE,
+      'match_exact_phrase' => TRUE,
+    ));
     $this->assertEqual(count($results), 2, 'Searching for match of exact case-insensitive phrase "the test" returned expected number of results');
     // Test against Phrase matching.
     $results = $hocr->search('test the', array(
-                 'case_sensitive' => TRUE,
-                 'match_exact_phrase' => FALSE,
-               ));
+      'case_sensitive' => TRUE,
+      'match_exact_phrase' => FALSE,
+    ));
     $this->assertEqual(count($results), 6, 'Test against exact phrase "the test" returned expected number of results');
     // Test Solr matching.
     $file = drupal_get_path('module', 'islandora_ocr') . '/tests/fixtures/solr_results.xml';


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1533
# What does this Pull Request do?

Adds a second return format to the OCR generation process to delay ingest until later.
# How should this be tested?

This likely shouldn't be tested on its own, and should be tested as part of [ISLANDORA-1533](https://jira.duraspace.org/browse/ISLANDORA-1533) (i.e., existing functionality should be maintained and new functionality should be working), as this is lower-level code used by higher-level things that can _actually_ be tested by someone.
# Background context:

As part of [ISLANDORA-1533](https://jira.duraspace.org/browse/ISLANDORA-1533): currently, OCR/HOCR datastreams are added to an object the moment they are generated. This makes it impossible to create a single consolidated OCR to append to a paged content object, as each OCR datastream would have to then be loaded individually out of Fedora. This gives an option to keep OCR derivatives where they are so they can be concatenated on the file system during the batch ingest process before finally adding them to the page.

**Tagging:** @Islandora/7-x-1-x-committers @ruebot 

---

QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
