### PR TITLE
ISLANDORA-1517 Include query fields in OCR search

### DIFF
--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -45,6 +45,12 @@ function islandora_ocr_highlighted_solr_search($query, $offset = 0, $limit = -1,
     "hl.snippets" => "8",
   ) + $params;
 
+   if (variable_get('islandora_solr_use_ui_qf', FALSE) || !islandora_solr_check_dismax()) {
+       // Put our "qf" in if we are configured to, or we have none from the
+       // request handler.
+       $params['qf'] = variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type');
+   }
+  
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
   $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
   $solr->setCreateDocuments(0);

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -45,12 +45,12 @@ function islandora_ocr_highlighted_solr_search($query, $offset = 0, $limit = -1,
     "hl.snippets" => "8",
   ) + $params;
 
-   if (variable_get('islandora_solr_use_ui_qf', FALSE) || !islandora_solr_check_dismax()) {
-       // Put our "qf" in if we are configured to, or we have none from the
-       // request handler.
-       $params['qf'] = variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type');
-   }
-  
+  if (variable_get('islandora_solr_use_ui_qf', FALSE) || !islandora_solr_check_dismax()) {
+    // Put our "qf" in if we are configured to or have none from the
+    // request handler.
+    $params['qf'] = variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type');
+  }
+
   $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
   $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
   $solr->setCreateDocuments(0);


### PR DESCRIPTION
Jira: https://jira.duraspace.org/browse/ISLANDORA-1517
## What does this Pull Request do?

Fixes [this bug](https://jira.duraspace.org/browse/ISLANDORA-1517), where query fields are not included in archive bookreader's interactive search when not provided by the request handler configuration.
Also takes advantage of this [pull request](https://github.com/Islandora/islandora_solr_search/pull/256), which allows the GUI-configured Query fields (qf; the fields for dismax/simple search) to be preferred over those defined in the selected request handler. **However it does not depend on it.**
## How should this be tested?
- Comment out (or delete) query fields setup in solr config request handler (example: see [your-fedora-server]:8080/solr/#/collection1/config).
- Configure query defaults > query fields in solr settings: /admin/islandora/search/islandora_solr/settings.
- Make sure "solr field containing OCR text" is set up here: /admin/islandora/tools/ocr.
- Go to internet archive book reader page and perform search on contents of book.
## Additional Notes:
- **Does this change require documentation to be updated?** No
- **Could this change impact execution of existing code?** Seems unlikely

Tagging:
- **@jordandukart** (component manager)
- **@DiegoPino**

Pat Dunlavey
Common Media Inc.
