### PR TITLE
Allow for other OCR creation engines than tesseract.

### DIFF
--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -132,7 +132,7 @@ class HOCR {
       // ppageno is not an explicitly required element within an ocr_page
       // element. Similarly, with the hOCR that gets generated with tesseract
       // the page number will always be 0.
-      if ((isset($page['ppageno']) && $page['ppageno'] == $page_number) || !isset($page['pageno'])) {
+      if ((isset($page['ppageno']) && $page['ppageno'] == $page_number) || !isset($page['ppageno'])) {
         return $this->getPropertyDimensions($page);
       }
     }

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -526,7 +526,7 @@ class HOCR {
       }
     }
     // Some HOCR implementations don't provide unique IDs for words. In this
-    // case let's use the node path as it's guarenteed to be unique. These IDs
+    // case let's use the node path as it's guaranteed to be unique. These IDs
     // are currently not used in any of the theme layer code.
     $properties = array_filter(array(
       'id' => $element->hasAttribute('id') ? $element->getAttribute('id') : $element->getNodePath(),

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -61,32 +61,31 @@ class HOCR {
   public static function isValid($file) {
     module_load_include('inc', 'islandora_ocr', 'includes/utilities');
     if (file_exists($file)) {
-      $version = self::getVersion($file);
-      return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
+      $creator = self::getCreator($file);
+      if ($creator) {
+        // The source was created by tesseract, for which we only support a
+        // minimum version. Check that now.
+        if (strrpos($creator, 'tesseract') === 0) {
+          $version = str_replace(array('tesseract', ' '), '', $creator);
+          return version_compare($version, islandora_ocr_required_tesseract_version()) >= 0;
+        }
+        return TRUE;
+      }
+      return FALSE;
     }
     return FALSE;
   }
 
   /**
-   * Gets the version of the give HOCR file.
-   *
-   * Parses the meta tags in the given file to determine the version. Older
-   * versions of tesseract don't include the version information.
-   *
-   * @param string $file
-   *   The absolute path to the HOCR file.
-   *
-   * @return string
-   *   The version if successful, FALSE otherwise.
+   * Gets the OCR engine creator.
    */
-  public static function getVersion($file) {
+  public static function getCreator($file) {
     @$doc = simplexml_load_file($file);
     if ($doc) {
       $doc->registerXPathNamespace('ns', 'http://www.w3.org/1999/xhtml');
       $content_attributes = $doc->xpath('/ns:html/ns:head/ns:meta[@name="ocr-system"]/@content');
-      $version = (string) reset($content_attributes);
-      $version = str_replace(array('tesseract', ' '), '', $version);
-      return empty($version) ? FALSE : $version;
+      $creator = (string) reset($content_attributes);
+      return empty($creator) ? FALSE : $creator;
     }
     return FALSE;
   }
@@ -128,7 +127,12 @@ class HOCR {
     $nodes = $this->findClassNodes('ocr_page');
     $pages = $this->getProperties($nodes);
     foreach ($pages as $page) {
-      if ($page['ppageno'] == $page_number) {
+      // For things that have page numbers set return the match. Otherwise
+      // return the first page in other pages array. It's to be noted that
+      // ppageno is not an explicitly required element within an ocr_page
+      // element. Similarly, with the hOCR that gets generated with tesseract
+      // the page number will always be 0.
+      if ((isset($page['ppageno']) && $page['ppageno'] == $page_number) || !isset($page['pageno'])) {
         return $this->getPropertyDimensions($page);
       }
     }

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -78,6 +78,12 @@ class HOCR {
 
   /**
    * Gets the OCR engine creator.
+   *
+   * @param string $file
+   *   The absolute path to the HOCR file.
+   *
+   * @return bool|string
+   *   The version if successful, FALSE otherwise.
    */
   public static function getCreator($file) {
     @$doc = simplexml_load_file($file);

--- a/includes/hocr.inc
+++ b/includes/hocr.inc
@@ -525,8 +525,11 @@ class HOCR {
         $ppageno = isset($matches[1]) ? intval($matches[1]) : NULL;
       }
     }
+    // Some HOCR implementations don't provide unique IDs for words. In this
+    // case let's use the node path as it's guarenteed to be unique. These IDs
+    // are currently not used in any of the theme layer code.
     $properties = array_filter(array(
-      'id' => $element->hasAttribute('id') ? $element->getAttribute('id') : NULL,
+      'id' => $element->hasAttribute('id') ? $element->getAttribute('id') : $element->getNodePath(),
       'class' => $element->hasAttribute('class') ? $element->getAttribute('class') : NULL,
       'dir' => $element->hasAttribute('dir') ? $element->getAttribute('dir') : NULL,
       'bbox' => $bbox));

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -131,13 +131,8 @@ function islandora_ocr_map_highlighted_fields_to_words(HOCR $hocr, array $search
   $highlighted_matches = array();
   foreach ($snippets as $snippet) {
     $matches = $hocr->search($snippet, $search_params);
-    $word_id = 1;
     foreach ($matches as $match) {
-      // Some hOCR implementations don't provide unique IDs for words. In this
-      // case let's grab a numerical one. It doesn't get used in any of the
-      // theme layer code that currently exists.
-      $id = isset($match['id']) ? $match['id'] : $word_id;
-      $word_id++;
+      $id = $match['id'];
       if (empty($highlighted_matches[$id])) {
         $highlighted_matches[$id] = $match;
       }

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -131,8 +131,13 @@ function islandora_ocr_map_highlighted_fields_to_words(HOCR $hocr, array $search
   $highlighted_matches = array();
   foreach ($snippets as $snippet) {
     $matches = $hocr->search($snippet, $search_params);
+    $word_id = 1;
     foreach ($matches as $match) {
-      $id = $match['id'];
+      // Some hOCR implementations don't provide unique IDs for words. In this
+      // case let's grab a numerical one. It doesn't get used in any of the
+      // theme layer code that currently exists.
+      $id = isset($match['id']) ? $match['id'] : $word_id;
+      $word_id++;
       if (empty($highlighted_matches[$id])) {
         $highlighted_matches[$id] = $match;
       }


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1624 
# What does this Pull Request do?

Allows HOCR from other creation engines than tesseract to have their bounding boxes rendered for use with IAV and OpenSeadragon.
# How should this be tested?

Books:

Test out HOCR generated via tesseract and have bounding boxes applied correctly when searching for terms within the IAV book.

Newspapers:

From search results from a specific indexed term bounding boxes are rendered correctly on the newspaper page when a result is clicked.

Will provide sample assets of other generated HOCR and a JP2 when I receive an uncopyrighted source copy that I can attach to the external JIRA ticket. 
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.
# Additional Information

I'm the maintainer for this module so someone else will need to have a look.

**Tagging:** @Islandora/7-x-1-x-committers 

---

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
