### PR TITLE
Change default tesseract languages to all installed ones.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -119,6 +119,8 @@ function islandora_ocr_tesseract_language_name($language) {
  *   the value is a human readable version of the language.
  */
 function islandora_ocr_get_enabled_tesseract_languages() {
-  $enabled_languages = array_filter(variable_get('islandora_ocr_tesseract_enabled_languages', array()));
+  $tesseract = variable_get('islandora_ocr_tesseract', '/usr/bin/tesseract');
+  $installed_languages = islandora_ocr_get_tesseract_installed_languages($tesseract);
+  $enabled_languages = array_filter(variable_get('islandora_ocr_tesseract_enabled_languages', drupal_map_assoc($installed_languages)));
   return array_merge(drupal_map_assoc($enabled_languages, 'islandora_ocr_tesseract_language_name'), array('no_ocr' => t('Do not perform OCR')));
 }


### PR DESCRIPTION
[ISLANDORA-1491](https://jira.duraspace.org/browse/ISLANDORA-1491)
# What does this Pull Request do?

Makes the array of enabled languages match what is shown on the admin page.
# What's new?

By default the set of enabled languages when viewing the admin page is all installed languages for Tesseract. The value returned for getting the enabled languages, relied on the variable value. That matches to a more assume nothing is enabled plan of action.

This PR changes so if the variable is not set, then the `islandora_ocr_get_enabled_tesseract_languages()` will also return an array of all installed languages.

Also, if you goto the OCR admin page and save the settings, then I think this issue is gone as you will set that variable to what you see on the screen.
# How should this be tested?

You need to have the _islandora_ocr_tesseract_enabled_languages_ variable unset.

Ensure you have tesseract properly installed with some languages displaying on the admin page **BUT DO NOT SAVE THAT PAGE**.

Create a Book object.
Add a Page and view the _Language_ dropdown.

Prior to the PR, it has one option _Do not perform OCR_. 
After the PR, you should have all the options you saw previously on the OCR Tool admin page.

Example:
- Does this change require documentation to be updated? No
- Does this change add any new dependencies? No
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
- Could this change impact execution of existing code? No
# Interested parties

// Guessing here based on the ticket.
@adam-vessey @DonRichards @qadan 
