### PR TITLE
Only ingest the datastream if it does not exist. Version clean-up.

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -447,21 +447,25 @@ function islandora_ocr_imagemagick_convert($src, $dest, $args) {
  */
 function islandora_ocr_update_datastream(AbstractObject $object, $file, $dsid, $label = NULL, $mimetype = NULL, $control_group = 'M', $copy = TRUE) {
   $mime_detector = new MimeDetect();
-  if (empty($object[$dsid])) {
+  $ingest = !isset($object[$dsid]);
+  if ($ingest) {
     $ds = $object->constructDatastream($dsid, $control_group);
   }
   else {
     $ds = $object[$dsid];
   }
   $ds->setContentFromFile($file, $copy);
-  $ds->label = isset($label) ? $label : $dsid;
-  if (isset($mimetype)) {
+  $label = isset($label) ? $label : $dsid;
+  if ($ds->label != $label) {
+    $ds->label = $label;
+  }
+  $mimetype = isset($mimetype) ? $mimetype : $mime_detector->getMimetype($file);
+  if ($ds->mimetype != $mimetype) {
     $ds->mimetype = $mimetype;
   }
-  else {
-    $ds->mimetype = $mime_detector->getMimetype($file);
+  if ($ingest) {
+    $object->ingestDatastream($ds);
   }
-  $object->ingestDatastream($ds);
   file_unmanaged_delete($file);
   return TRUE;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1995

# What does this Pull Request do?
Does not attempt to ingest an existing datastream when "updating" as this behavior will become deprecated in 7.x-1.10. Also allows for less versions to be created when creating/updating a datastream.

# What's new?
Datastream does not attempt to be ingested but is instead updated and less versions created overall.

# How should this be tested?
Ingest a new page object.
Note that derivatives create normally on a new page object with a lower amount of versions.

Re-generate derivatives on an existing page object.
Note that derivatives regenerate normally on the existing page object with an increment of one for a version.

Example:
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties
@Islandora/7-x-1-x-committers
