### PR TITLE
Fix url to GSearch XSLT transformation in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each text node of each element in the HOCR datastream must be placed in order in
 
 Any objects that were previously ingested but require this functionality will need to be re-indexed.
 
-[Reference Implementation](https://github.com/discoverygarden/basic-solr-config/blob/modular/islandora_transforms/XML_text_nodes_to_solr.xslt)
+[XSLT Reference Implementation for GSearch](https://github.com/discoverygarden/islandora_transforms/blob/master/XML_text_nodes_to_solr.xslt)
 
 
 ### Tesseract


### PR DESCRIPTION
Originally reported and fix submitted by [@zuphilip](https://github.com/zuphilip) via https://github.com/Islandora/islandora_ocr/pull/82

No Jira ticket needed. It is a minor Code/Documentation tasks.

# What does this Pull Request do?

Fixes wrong link to the OCR XSLT Gsearch Reference implementation. Adds a few extra words to the link's text.

# Additional Notes:
Thanks to @zuphilip for making the [original Pull request](https://github.com/Islandora/islandora_ocr/pull/82). This is a redo to comply with our [Islandora CLA](https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements).

# Interested parties
@mjordan, @manez @willtp87 @Islandora/7-x-1-x-committers