### PR TITLE
ISLANDORA-2394: Spelling correction

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -99,14 +99,16 @@ function islandora_ocr_get_tesseract_installed_languages($tesseract = NULL) {
  */
 function islandora_ocr_tesseract_language_name($language) {
   $language_names = array(
-    'eng' => t('English'),
-    'fra' => t('French'),
-    'deu-frak' => t('German'),
-    'por' => t('Portugese'),
-    'spa' => t('Spanish'),
-    'hin' => t('Hindi'),
-    'jpn' => t('Japanese'),
-    'ita' => t('Italian'),
+      'eng' => t('English'),
+      'fra' => t('French'),
+      'deu-frak' => t('German - Fraktur'),
+      'por' => t('Portuguese'),
+      'spa' => t('Spanish'),
+      'hin' => t('Hindi'),
+      'jpn' => t('Japanese'),
+      'ita' => t('Italian'),
+      'lat' => t('Latin'),
+      'deu' => t('German')
   );
   return isset($language_names[$language]) ? $language_names[$language] : $language;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -98,18 +98,21 @@ function islandora_ocr_get_tesseract_installed_languages($tesseract = NULL) {
  *   otherwise the abbreviation is returned unaltered.
  */
 function islandora_ocr_tesseract_language_name($language) {
-  $language_names = array(
-      'eng' => t('English'),
-      'fra' => t('French'),
-      'deu-frak' => t('German - Fraktur'),
-      'por' => t('Portuguese'),
-      'spa' => t('Spanish'),
-      'hin' => t('Hindi'),
-      'jpn' => t('Japanese'),
-      'ita' => t('Italian'),
-      'lat' => t('Latin'),
-      'deu' => t('German')
-  );
+    $language_names = module_invoke_all('get_ocr_tesseract_languages');
+    if (is_null($language_names)){
+      $language_names = array(
+          'eng' => t('English'),
+          'fra' => t('French'),
+          'deu-frak' => t('German - Fraktur'),
+          'por' => t('Portuguese'),
+          'spa' => t('Spanish'),
+          'hin' => t('Hindi'),
+          'jpn' => t('Japanese'),
+          'ita' => t('Italian'),
+          'lat' => t('Latin'),
+          'deu' => t('German')
+      );
+    }
   return isset($language_names[$language]) ? $language_names[$language] : $language;
 }
 

--- a/islandora_ocr.api.php
+++ b/islandora_ocr.api.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Hooks for islandora_ocr module
+ */
+
+
+/**
+ * Respond to node view count being incremented.
+ *
+ * This hooks allows modules to define their own list of human readable names for the given tesseract abbreviation
+ *
+ */
+function hook_get_ocr_tesseract_languages() {
+
+    // https://github.com/tesseract-ocr/tesseract/wiki/Data-Files
+    return array(
+        'swa' => t('Swahili'),
+        'swe' => t('Swedish'),
+        'syr' => t('Syriac'),
+        'tam' => t('Tamil'),
+        'tel' => t('Telugu'),
+        'tgk' => t('Tajik'),
+        'tgl' => t('Tagalog'),
+        'tha' => t('Thai'),
+        'tir' => t('Tigrinya'),
+        'tur' => t('Turkish'),
+        'uig' => t('Uighur; Uyghur'),
+        'ukr' => t('Ukrainian'),
+        'urd' => t('Urdu'),
+        'uzb' => t('Uzbek'),
+        'uzb_cyrl' => t('Uzbek - Cyrillic'),
+        'vie' => t('Vietnamese'),
+        'yid' => t('Yiddish'),
+    );
+}


### PR DESCRIPTION
ISLANDORA-2394: https://jira.duraspace.org/browse/ISLANDORA-2394 

Fixing spelling on Portuguese, German to match tesseract (selfishly adding in latin for our institutional needs) 

Related to closed pull request #93 

I do have a CLA on file: 
https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements