### PR TITLE
ISLANDORA-2394: Spelling correction

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -99,14 +99,16 @@ function islandora_ocr_get_tesseract_installed_languages($tesseract = NULL) {
  */
 function islandora_ocr_tesseract_language_name($language) {
   $language_names = array(
-    'eng' => t('English'),
-    'fra' => t('French'),
-    'deu-frak' => t('German'),
-    'por' => t('Portugese'),
-    'spa' => t('Spanish'),
-    'hin' => t('Hindi'),
-    'jpn' => t('Japanese'),
-    'ita' => t('Italian'),
+      'eng' => t('English'),
+      'fra' => t('French'),
+      'deu-frak' => t('German - Fraktur'),
+      'por' => t('Portuguese'),
+      'spa' => t('Spanish'),
+      'hin' => t('Hindi'),
+      'jpn' => t('Japanese'),
+      'ita' => t('Italian'),
+      'lat' => t('Latin'),
+      'deu' => t('German')
   );
   return isset($language_names[$language]) ? $language_names[$language] : $language;
 }


### PR DESCRIPTION
ISLANDORA-2394: https://jira.duraspace.org/browse/ISLANDORA-2394

Fixing spelling on Portuguese, German to match tesseract (selfishly adding in latin for our institutional needs)

Related to closed pull request #93

I do have a CLA on file:
https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements