### PR TITLE
ISLANDORA-2504 Fix to not use tile 0 of JP2s for derivatives

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -375,6 +375,32 @@ function islandora_ocr_get_identify() {
 }
 
 /**
+ * Uses Imagemagick's identify to determine if the file is a TIFF.
+ *
+ * @param string $file
+ *   A file-system path to the file in question.
+ *
+ * @return bool
+ *   A boolean indicating if the file contains a TIFF.
+ */
+function islandora_ocr_is_tiff($file) {
+  $identify = islandora_ocr_get_identify();
+
+  $escaped_file = escapeshellarg(drupal_realpath($file));
+
+  $codec = exec(escapeshellcmd("$identify -format \"%m\" ") . $escaped_file);
+
+  $is_tiff = strrpos(strtolower($codec), 'tiff');
+
+  /* Avoid false negatives after strrpos */
+  if ($is_tiff !== FALSE) {
+    $is_tiff = TRUE;
+  }
+
+  return $is_tiff;
+}
+
+/**
  * Calls imagemagick's convert command with the given arguments.
  *
  * @param string $src
@@ -390,7 +416,10 @@ function islandora_ocr_get_identify() {
  *   The destination file path if successful otherwise FALSE.
  */
 function islandora_ocr_imagemagick_convert($src, $dest, $args) {
-  $src = drupal_realpath($src) . '[0]';
+  $src = drupal_realpath($src);
+  if (islandora_ocr_is_tiff($src)) {
+    $src = $src . '[0]';
+  }
   $dest = drupal_realpath($dest);
   $context = array(
     'source' => $src,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2504

* Previous JIRA: https://jira.lyrasis.org/browse/ISLANDORA-1416
* Previous fix: https://github.com/Islandora/islandora_solution_pack_large_image/pull/149

# What does this Pull Request do?

Checks to see if the file to be OCRed is a TIFF. If so, append "[0]" to use the first page for the derivative (as before). If not, refrain from doing so, so as to not use the first tile of a JP2 file.

# What's new?
* Adds a tiff-detection function
* Uses it to properly generate derivatives for OCRing

# How should this be tested?

Attached to the JIRA ticket is a JP2 file. In a test environment, comment out: 
https://github.com/Islandora/islandora_ocr/blob/13f5c9a917e1b7689bdb0702d343c185eb4f08d1/includes/derivatives.inc#L339
and
https://github.com/Islandora/islandora_ocr/blob/13f5c9a917e1b7689bdb0702d343c185eb4f08d1/includes/derivatives.inc#L459 
to preserve the generated derivatives. Ingest the JP2 and rescue the derivative from `/var/www/drupal/sites/YOUR_SITE/temp/`. Observe that it is just the top-left corner of the image (tile[0]), like the first .tif file also attached to the JIRA ticket. Note that the OCR text generated from this tile is useless. Apply the PR and repeat the process. Observe that the new derivative is now the full page. Note that the generated OCR is marginally more useful (and would be a lot more useful if the test file happened to be more amenable to OCRing).

# Additional Notes:
As noted above, this is a direct port of the fix for this issue that was fixed five years ago in the Large Image SP.

# Interested parties
@Islandora/7-x-1-x-committers
